### PR TITLE
文字コード関連

### DIFF
--- a/ptex2pdf-tlpost.pl
+++ b/ptex2pdf-tlpost.pl
@@ -36,13 +36,13 @@ my %ptex2pdf = (
   '1' => {
     'name' => 'pTeX to pdf',
     'program' => 'ptex2pdf',
-    'arguments' => '-ot, $synctexoption, $fullname',
+    'arguments' => '-ot, -kanji=utf8 $synctexoption, $fullname',
     'showPdf' => 'true'
   },
   '2' => {
     'name' => 'pLaTeX to pdf',
     'program' => 'ptex2pdf',
-    'arguments' => '-l, -ot, $synctexoption, $fullname',
+    'arguments' => '-l, -ot, -kanji=utf8 $synctexoption, $fullname',
     'showPdf' => 'true'
   },
   '3' => {

--- a/ptex2pdf-tlpost.pl
+++ b/ptex2pdf-tlpost.pl
@@ -46,30 +46,24 @@ my %ptex2pdf = (
     'showPdf' => 'true'
   },
   '3' => {
-    'name' => 'pLaTeX/SJIS to pdf',
-    'program' => 'ptex2pdf',
-    'arguments' => '-l, -ot, $synctexoption -kanji=sjis, $fullname',
-    'showPdf' => 'true'
-  },
-  '4' => {
     'name' => 'upTeX to pdf',
     'program' => 'ptex2pdf',
     'arguments' => '-u, -ot, $synctexoption, $fullname',
     'showPdf' => 'true'
   },
-  '5' => {
+  '4' => {
     'name' => 'upLaTeX to pdf',
     'program' => 'ptex2pdf',
     'arguments' => '-u, -l, -ot, $synctexoption, $fullname',
     'showPdf' => 'true'
   },
-  '6' => {
+  '5' => {
     'name' => 'pBibTeX (Japanese BibTeX)',
     'program' => 'pbibtex',
     'arguments' => '$basename',
     'showPdf' => 'false'
   },
-  '7' => {
+  '6' => {
     'name' => 'mendex (Japanese MakeIndex)',
     'program' => 'mendex',
     'arguments' => '$basename',


### PR DESCRIPTION
既定エンコードがUTF-8なので，Shift_JISの設定を消してみました．また，-kanji=utf8を追加しました（Windowsでターミナルへの出力が化けるので）．