### PR TITLE
Add utf8 options to pbibtex and mendex.

### DIFF
--- a/ptex2pdf-tlpost.pl
+++ b/ptex2pdf-tlpost.pl
@@ -58,7 +58,7 @@ my %ptex2pdf = (
   '5' => {
     'name' => 'pBibTeX (Japanese BibTeX)',
     'program' => 'pbibtex',
-    'arguments' => '$basename',
+    'arguments' => '-kanji=utf8, $basename',
     'showPdf' => 'false'
   },
   '6' => {
@@ -70,7 +70,7 @@ my %ptex2pdf = (
   '7' => {
     'name' => 'mendex (Japanese MakeIndex)',
     'program' => 'mendex',
-    'arguments' => '$basename',
+    'arguments' => '-U, $basename',
     'showPdf' => 'false'
   },
   '8' => {


### PR DESCRIPTION
p(La)TeX に -kanji=utf8 が付いているなら .aux や .idx は UTF-8N で output されるはずなので、input を確実にするためには pBibTeX と mendex もオプションが要ると思いますので、付けてみました。