### PR TITLE
Drop directory name from bname

### DIFF
--- a/ptex2pdf.lua
+++ b/ptex2pdf.lua
@@ -354,6 +354,9 @@ else
     -- if it has already an extension, we need to drop it to get the dvi name
     bname = string.gsub(filename, "^(.*)%.[^.]+$", "%1")
   end
+  -- filename may contain "/", but the intermediate output is written
+  -- in current directory, so we need to drop it
+  bname = string.gsub(bname, "^.*/(.*)$", "%1")
 end
 
 -- we are still here, so we found a file


### PR DESCRIPTION
現在の ptex2pdf で test.tex を subdirectory などに置いた場合

~~~~
$ ptex2pdf -l subdir/test.tex
This is ptex2pdf[.lua] version 0.8.
Processing subdir/test.tex
This is e-pTeX, Version 3.14159265-p3.7.1-161114-2.6 (utf8.euc) (TeX Live 2017/dev) (preloaded format=platex)
 restricted \write18 enabled.
entering extended mode
(./subdir/test.tex
 … 略 …
Output written on test.dvi (1 page, 760 bytes).
Transcript written on test.log.
subdir/test.dvi -> test.pdf

dvipdfmx:fatal: Could not open specified DVI (or XDV) file: subdir/test.dvi

Output file removed.
ptex2pdf processing of subdir/test.tex failed.
~~~~

でエラーになります。current directory に test.dvi があるので、bname は subdir/ を消したものであったほうがよいと思います。（書いたコードは Unix 環境でしかまだ試していません）